### PR TITLE
CLOUD-1075 forking this to the RR org, not tvaughanRR personal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Enables AWS Config and adds managed config rules with good defaults.
 
+This is a RocketReach fork of the https://github.com/trussworks/terraform-aws-config repository that provides AWS Config
+infrastructure for our main production account, which we've configured to capture the config changes in all our other
+accounts.
+
+We branched this in 2023/09 because the original module didn't support excluding Config resource_types and when we tried
+to include a specific set of resource_types, that didn't work either.
+
 ## Supported AWS Config Rules
 
 ### ACM

--- a/config-service.tf
+++ b/config-service.tf
@@ -33,9 +33,13 @@ resource "aws_config_configuration_recorder" "main" {
   role_arn = aws_iam_role.main[count.index].arn
 
   recording_group {
-    all_supported                 = length(var.resource_types) == 0 ? true : false
-    include_global_resource_types = length(var.resource_types) == 0 ? var.include_global_resource_types : null
-    resource_types                = length(var.resource_types) == 0 ? null : var.resource_types
+    all_supported                 = false
+    exclusion_by_resource_types {
+      resource_types = var.exclusion_by_resource_types
+    }
+    recording_strategy {
+      use_only = "EXCLUSION_BY_RESOURCE_TYPES"
+    }
   }
 
   recording_mode {

--- a/variables.tf
+++ b/variables.tf
@@ -469,6 +469,12 @@ variable "exclude_permission_boundary" {
   default     = false
 }
 
+variable "exclusion_by_resource_types" {
+  description = "A list that specifies the types of AWS resources for which AWS Config does *not* record configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types."
+  type        = list(string)
+  default     = []
+}
+
 variable "expected_delivery_window_age" {
   description = "Maximum age in hours of the most recent delivery to CloudWatch logs that satisfies compliance."
   type        = number


### PR DESCRIPTION
Back in 2023 when I first forked this terraform-aws-config repo I accidentally forked it to my tvaughanRR github account instead of the rocketreach organization's account

I made some changes to the fork to support excluding resource types in our AWS Config settings, so this PR:

1) forks the modern terraform-aws-config module from trussworks into our rocketreach organization
2) repeats the resource type exclusion changes I made in the tvaughanRR repo

If this gets merged in, then I'll update our use of this module [here ](https://github.com/rocketreach/terraform-modules-aws/blob/898eb47e338d57b24b2c220606bad65735c24f08/config/v1/main.tf#L40)to change the source from `tvaughanRR` to `rocketreach`