### PR TITLE
CLOUD-1580 updates forked module to allow additional policy attachments

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -119,3 +119,10 @@ resource "aws_iam_role_policy_attachment" "aws-config-policy" {
   role       = aws_iam_role.main[count.index].name
   policy_arn = aws_iam_policy.aws-config-policy[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "additional_policies" {
+  count = var.enable_config_recorder ? length(var.additional_policy_arns) : 0
+
+  role = aws_iam_role.main[count.index].name
+  policy_arn = var.additional_policy_arns[count.index]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "acm_days_to_expiration" {
   default     = 14
 }
 
+variable "additional_policy_arns" {
+  description = "Any additional policies to attach to the Config role.  Provide an array of ARNs, keeping in mind that this module already attaches a couple policies to the role, so you might hit the 10-policy-per-role limit faster than you think."
+  type        = list(string)
+  default     = []
+}
+
 variable "aggregate_organization" {
   description = "Aggregate compliance data by organization"
   type        = bool


### PR DESCRIPTION
To avoid accumulating a lot of false alarms w.r.t. "Illegal API Call" in our CloudTrail warnings, we should be able to pass in additional permissions to the AWS Config role on an account-by-account basis.

This is step 1 to allowing that to happen (step 2 is that I'll need to "pass through" this list variable from our terraform-aws-modules/config/v1 wrapper)